### PR TITLE
Fix FTX.US authentication headers

### DIFF
--- a/FTX.Net/FTX.Net.xml
+++ b/FTX.Net/FTX.Net.xml
@@ -2597,7 +2597,7 @@
             Size of the desired payment
             </summary>
         </member>
-        <member name="P:FTX.Net.Objects.FTXPay.FTXAppOrder.AllowTip">
+        <member name="P:FTX.Net.Objects.FTXPay.FTXAppOrder.AllowTips">
             <summary>
             Whether or not tips are allowed for the payment
             </summary>

--- a/FTX.Net/Interfaces/SubClients/IFTXSubClientPay.cs
+++ b/FTX.Net/Interfaces/SubClients/IFTXSubClientPay.cs
@@ -32,12 +32,12 @@ namespace FTX.Net.Interfaces.SubClients
         /// <param name="asset">The currency of the payment</param>
         /// <param name="notes">Notes about this order that are private to the merchant</param>
         /// <param name="quantity">Size of the desired payment</param>
-        /// <param name="allowTip">Whether or not tips are allowed for the payment</param>
+        /// <param name="allowTips">Whether or not tips are allowed for the payment</param>
         /// <param name="clientOrderId">ID for you to track the order with (must be unique to your FTX Pay app)</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
 #pragma warning restore 1570
-        Task<WebCallResult<FTXAppOrder>> CreateOrderAsync(long appId, string asset, decimal quantity, bool allowTip, string? notes = null, string? clientOrderId = null, CancellationToken ct = default);
+        Task<WebCallResult<FTXAppOrder>> CreateOrderAsync(long appId, string asset, decimal quantity, bool allowTips, string? notes = null, string? clientOrderId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get orders for an app

--- a/FTX.Net/Objects/FTXPay/FTXAppOrder.cs
+++ b/FTX.Net/Objects/FTXPay/FTXAppOrder.cs
@@ -33,7 +33,7 @@ namespace FTX.Net.Objects.FTXPay
         /// <summary>
         /// Whether or not tips are allowed for the payment
         /// </summary>
-        public bool AllowTip { get; set; }
+        public bool AllowTips { get; set; }
         /// <summary>
         /// ID for you to track the order with (must be unique to your FTX Pay app)
         /// </summary>

--- a/FTX.Net/SubClients/FTXSubClientPay.cs
+++ b/FTX.Net/SubClients/FTXSubClientPay.cs
@@ -56,17 +56,17 @@ namespace FTX.Net.SubClients
         /// <param name="asset">The currency of the payment</param>
         /// <param name="notes">Notes about this order that are private to the merchant</param>
         /// <param name="quantity">Size of the desired payment</param>
-        /// <param name="allowTip">Whether or not tips are allowed for the payment</param>
+        /// <param name="allowTips">Whether or not tips are allowed for the payment</param>
         /// <param name="clientOrderId">ID for you to track the order with (must be unique to your FTX Pay app)</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
 #pragma warning restore 1570
-        public async Task<WebCallResult<FTXAppOrder>> CreateOrderAsync(long appId, string asset, decimal quantity, bool allowTip, string? notes = null, string? clientOrderId = null, CancellationToken ct = default)
+        public async Task<WebCallResult<FTXAppOrder>> CreateOrderAsync(long appId, string asset, decimal quantity, bool allowTips, string? notes = null, string? clientOrderId = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddParameter("coin", asset);
             parameters.AddParameter("size", quantity.ToString(CultureInfo.InvariantCulture));
-            parameters.AddParameter("allowTip", allowTip.ToString());
+            parameters.AddParameter("allowTips", allowTips.ToString());
             parameters.AddOptionalParameter("notes", notes);
             parameters.AddOptionalParameter("clientOrderId", clientOrderId);
             return await _baseClient.SendFTXRequest<FTXAppOrder>(_baseClient.GetUri($"ftxpay/apps/{appId}/orders"), HttpMethod.Post, ct, parameters, signed: true).ConfigureAwait(false);

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ For the basic client options see also the CryptoExchange.Net [docs](https://gith
 | ----------- | ----------- | ---------|
 |`AffiliateCode`|Affiliate code which will be sent when placing orders|`jkorf-net`
 
+## FAQ
+**Does this library support the FTX.US**  
+Yes. Switch by changing the BaseAddress in the client options.
+
 ## Release notes
 * Version 0.1.7 - 11 Oct 2021
     * Fixed nullable properties on FTXPosition model


### PR DESCRIPTION
Based on: https://docs.ftx.us/?csharp#authentication
Authentication headers are different from `ftx.com`.

The fix is not the nicest one, it simply verifies what endpoint was set in client options and based on that decides headers.
As far as these crypto exchanges are not going to open a new domain for each country and as far as it remains the US and remaining world, I think the fix is fine.

There was also one issue for https://docs.ftx.us/?csharp#create-order
CreateOrder throws an error that `allowTip` is an unknown parameter. So I changed it to `allowTips` and it worked. But it seems this value is not going to their server. But at least the main functionally is working.
