### PR TITLE
Fix nullable properties on FTXUserTrade

### DIFF
--- a/FTX.Net/Objects/Spot/FTXUserTrade.cs
+++ b/FTX.Net/Objects/Spot/FTXUserTrade.cs
@@ -54,11 +54,11 @@ namespace FTX.Net.Objects.Spot
         /// <summary>
         /// Order id
         /// </summary>
-        public long OrderId { get; set; }
+        public long? OrderId { get; set; }
         /// <summary>
         /// Trade id
         /// </summary>
-        public long TradeId { get; set; }
+        public long? TradeId { get; set; }
         /// <summary>
         /// Order price
         /// </summary>


### PR DESCRIPTION
From FTX:
Below are all our fills type:
    ORDER = ‘order’
    LIQUIDATION = ‘liquidation’
    BACKSTOP = ‘backstop’
    ADL = ‘adl’
    EXPIRATION = ‘expiration’
    OTC = ‘otc’
    FTT_UNLOCK = ‘ftt_unlock’
tradeId and orderId are only populated where there is a counterparty, so these will be null unless fill type = 'order'