### PR TITLE
Feature/add network param to get withdrawal fees

### DIFF
--- a/FTX.Net/Clients/TradeApi/FTXClientTradeApiAccount.cs
+++ b/FTX.Net/Clients/TradeApi/FTXClientTradeApiAccount.cs
@@ -82,13 +82,14 @@ namespace FTX.Net.Clients.TradeApi
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<FTXWithdrawalFee>> GetWithdrawalFeesAsync(string asset, decimal quantity, string address, string? tag = null, string? subaccountName = null, CancellationToken ct = default)
+        public async Task<WebCallResult<FTXWithdrawalFee>> GetWithdrawalFeesAsync(string asset, decimal quantity, string address, string? tag = null, string? network = null, string? subaccountName = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
             parameters.AddParameter("coin", asset);
             parameters.AddParameter("size", quantity.ToString(CultureInfo.InvariantCulture));
             parameters.AddParameter("address", address);
             parameters.AddOptionalParameter("tag", tag);
+            parameters.AddOptionalParameter("method", network);
             return await _baseClient.SendFTXRequest<FTXWithdrawalFee>(_baseClient.GetUri("wallet/withdrawal_fee"), HttpMethod.Get, ct, parameters, signed: true, additionalHeaders: FTXClient.GetSubaccountHeader(subaccountName)).ConfigureAwait(false);
         }
 

--- a/FTX.Net/FTX.Net.xml
+++ b/FTX.Net/FTX.Net.xml
@@ -1722,7 +1722,7 @@
             <param name="quantity">Quantity to withdraw</param>
             <param name="address">Address to withdraw to</param>
             <param name="tag">Address tag</param>
-            <param name="network">Network to us</param>
+            <param name="network">Network to use</param>
             <param name="password">Withdrawal password if required</param>
             <param name="code">Two factor authentication code if required</param>
             <param name="subaccountName">Subaccount name to execute this request for</param>

--- a/FTX.Net/FTX.Net.xml
+++ b/FTX.Net/FTX.Net.xml
@@ -347,7 +347,7 @@
         <member name="M:FTX.Net.Clients.TradeApi.FTXClientTradeApiAccount.GetAirdropsAsync(System.Nullable{System.DateTime},System.Nullable{System.DateTime},System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:FTX.Net.Clients.TradeApi.FTXClientTradeApiAccount.GetWithdrawalFeesAsync(System.String,System.Decimal,System.String,System.String,System.String,System.Threading.CancellationToken)">
+        <member name="M:FTX.Net.Clients.TradeApi.FTXClientTradeApiAccount.GetWithdrawalFeesAsync(System.String,System.Decimal,System.String,System.String,System.String,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:FTX.Net.Clients.TradeApi.FTXClientTradeApiAccount.GetSavedAddressesAsync(System.String,System.String,System.Threading.CancellationToken)">
@@ -1740,7 +1740,7 @@
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
-        <member name="M:FTX.Net.Interfaces.Clients.TradeApi.IFTXClientTradeApiAccount.GetWithdrawalFeesAsync(System.String,System.Decimal,System.String,System.String,System.String,System.Threading.CancellationToken)">
+        <member name="M:FTX.Net.Interfaces.Clients.TradeApi.IFTXClientTradeApiAccount.GetWithdrawalFeesAsync(System.String,System.Decimal,System.String,System.String,System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Get withdrawal fees
             <para><a href="https://docs.ftx.com/#get-withdrawal-fees" /></para>
@@ -1749,6 +1749,7 @@
             <param name="quantity">Quantity</param>
             <param name="address">Address</param>
             <param name="tag">Tag</param>
+            <param name="network">Network to use</param>
             <param name="subaccountName">Subaccount name to execute this request for</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>

--- a/FTX.Net/Interfaces/Clients/TradeApi/IFTXClientTradeApiAccount.cs
+++ b/FTX.Net/Interfaces/Clients/TradeApi/IFTXClientTradeApiAccount.cs
@@ -128,10 +128,11 @@ namespace FTX.Net.Interfaces.Clients.TradeApi
         /// <param name="quantity">Quantity</param>
         /// <param name="address">Address</param>
         /// <param name="tag">Tag</param>
+        /// <param name="network">Network to use</param>
         /// <param name="subaccountName">Subaccount name to execute this request for</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<FTXWithdrawalFee>> GetWithdrawalFeesAsync(string asset, decimal quantity, string address, string? tag = null, string? subaccountName = null, CancellationToken ct = default);
+        Task<WebCallResult<FTXWithdrawalFee>> GetWithdrawalFeesAsync(string asset, decimal quantity, string address, string? tag = null, string? network = null, string? subaccountName = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get saved addresses

--- a/FTX.Net/Interfaces/Clients/TradeApi/IFTXClientTradeApiAccount.cs
+++ b/FTX.Net/Interfaces/Clients/TradeApi/IFTXClientTradeApiAccount.cs
@@ -101,7 +101,7 @@ namespace FTX.Net.Interfaces.Clients.TradeApi
         /// <param name="quantity">Quantity to withdraw</param>
         /// <param name="address">Address to withdraw to</param>
         /// <param name="tag">Address tag</param>
-        /// <param name="network">Network to us</param>
+        /// <param name="network">Network to use</param>
         /// <param name="password">Withdrawal password if required</param>
         /// <param name="code">Two factor authentication code if required</param>
         /// <param name="subaccountName">Subaccount name to execute this request for</param>


### PR DESCRIPTION
Hi! It seems that FTX have added the ability to query withdrawal fees for networks other than the default.
Their API docs have been updated as well: https://docs.ftx.com/#get-withdrawal-fees
This PR adds a new optional parameter "network" to allow the user to specify which network they want to get withdrawal fees for.