### PR TITLE
Feature/add network to withdrawals and deposits

### DIFF
--- a/FTX.Net/Objects/Models/FTXDeposit.cs
+++ b/FTX.Net/Objects/Models/FTXDeposit.cs
@@ -56,6 +56,11 @@ namespace FTX.Net.Objects.Models
         [JsonProperty("confirmedTime")]
         public DateTime ConfirmTime { get; set; }
         /// <summary>
+        /// Protocol used for the blockchain transfer
+        /// </summary>
+        [JsonProperty("method")]
+        public string? Network { get; set; }
+        /// <summary>
         /// Transaction id
         /// </summary>
         [JsonProperty("txid")]

--- a/FTX.Net/Objects/Models/FTXWithdrawal.cs
+++ b/FTX.Net/Objects/Models/FTXWithdrawal.cs
@@ -47,6 +47,11 @@ namespace FTX.Net.Objects.Models
         [JsonProperty("time")]
         public DateTime Timestamp { get; set; }
         /// <summary>
+        /// Protocol used for the blockchain transfer
+        /// </summary>
+        [JsonProperty("method")]
+        public string? Network { get; set; }
+        /// <summary>
         /// Transaction id
         /// </summary>
         [JsonProperty("txid")]


### PR DESCRIPTION
Hi Jan,

FTX shows the network in their [get withdrawal history](https://docs.ftx.com/#get-withdrawal-history) and [get deposit history](https://docs.ftx.com/#get-deposit-history) APIs (although they forgot to add it to their documentation for the latter endpoint!). I've confirmed it with them and also tested by fetching data from those endpoints. Where the transaction is not a blockchain transaction, the network (method) is null.

This PR adds the network property to the withdrawal and deposit models. Thanks!